### PR TITLE
mwdb-core 2.2.0 compatibility

### DIFF
--- a/mwdb_plugin_drakvuf/config.py
+++ b/mwdb_plugin_drakvuf/config.py
@@ -1,5 +1,5 @@
 from mwdb.core.config import AppConfig, app_config
-from mwdb.core.typedconfig import Config, group_key, key, section
+from typedconfig import Config, group_key, key, section
 
 
 @section("drakvuf")


### PR DESCRIPTION
see https://mwdb.readthedocs.io/en/latest/whats-changed.html#backend-typed-config-is-no-longer-embedded-in-mwdb-package