### PR TITLE
Resolve Metakey to Attribute

### DIFF
--- a/mwdb_plugin_drakvuf/plugin.py
+++ b/mwdb_plugin_drakvuf/plugin.py
@@ -2,7 +2,7 @@ import logging
 import requests
 
 from mwdb.core.plugins import PluginAppContext, PluginHookHandler
-from mwdb.model import db, File, MetakeyDefinition
+from mwdb.model import db, File, AttributeDefinition
 
 from .config import config
 
@@ -52,7 +52,7 @@ def configure():
     This will be called by 'mwdb configure' command.
     """
     logger.info("Configuring 'drakvuf' attribute key.")
-    attribute = MetakeyDefinition(key="drakvuf",
+    attribute = AttributeDefinition(key="drakvuf",
                                   url_template=f"{config.drakvuf.drakvuf_url}/progress/$value",
                                   label="Drakvuf analysis",
                                   description="Reference to the Drakvuf analysis for file")


### PR DESCRIPTION
Metakey no longer exists in newer version of mwdb-core, change updates to the proper mapping. 

https://github.com/CERT-Polska/mwdb-core/issues/301